### PR TITLE
Exclude html from oxfmt so pnpm prettier passes

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -18,6 +18,7 @@
     "**/.next/**",
     "**/.lighthouseci/**",
     "pnpm-lock.yaml",
-    "**/*.css"
+    "**/*.css",
+    "**/*.html"
   ]
 }


### PR DESCRIPTION
## Problem

`pnpm prettier` fails on `main`:

```
.claude/skills/ga4-report/template.html
Format issues found in above 1 files.
```

CI only runs `pnpm lint`, so this went unnoticed.

## Why exclude rather than format

`template.html` is the only html file oxfmt actually reaches. The repo has twelve tracked html files and the other eleven are under `apps/blog/public/`, which `ignorePatterns` already excludes.

Formatting it rewrites the embedded `<style>` block: `[data-theme="dark"]` becomes `[data-theme='dark']`, and every compact one-line rule is expanded. That is roughly 1500 changed lines in a hand-tuned design asset that the ga4-report skill copies and edits by hand.

That is CSS formatting, and this repo already decided oxfmt does not own CSS — `**/*.css` has been in `ignorePatterns`, with stylelint handling it. The lefthook oxfmt glob (`*.{ts,cts,tsx,js,cjs,jsx,json,md,yaml,yml}`) never listed html either. CSS-in-html was simply the gap between those two, reachable only through a whole-directory `oxfmt .`.

Adding `**/*.html` closes the gap and makes the hook and the full run agree.

## Verification

`pnpm prettier` passes, 681 files.
